### PR TITLE
ll: close remotes with `POWER_OFF` instead `TIMEOUT`

### DIFF
--- a/model/controller/link_layer_controller.cc
+++ b/model/controller/link_layer_controller.cc
@@ -5134,8 +5134,8 @@ void LinkLayerController::Tick() {
 
 void LinkLayerController::Close() {
   for (auto handle : connections_.GetAclHandles()) {
-    Disconnect(handle, ErrorCode::CONNECTION_TIMEOUT,
-               ErrorCode::CONNECTION_TIMEOUT);
+    Disconnect(handle, ErrorCode::REMOTE_DEVICE_TERMINATED_CONNECTION_POWER_OFF,
+               ErrorCode::REMOTE_DEVICE_TERMINATED_CONNECTION_POWER_OFF);
   }
 }
 


### PR DESCRIPTION
The host may trigger re-connect logic on `CONNECTION_TIMEOUT`, avoid this behavior when the disconnection is from a device being closed