### PR TITLE
Explicitly set line buffered mode

### DIFF
--- a/desktop/root_canal_main.cc
+++ b/desktop/root_canal_main.cc
@@ -25,6 +25,7 @@
 #include <fstream>
 #include <future>
 #include <optional>
+#include <cstdio>
 
 #include "model/setup/async_manager.h"
 #include "net/posix/posix_async_socket_connector.h"
@@ -54,6 +55,10 @@ DEFINE_uint32(link_port, 6403, "link server tcp port");
 DEFINE_uint32(link_ble_port, 6404, "le link server tcp port");
 
 int main(int argc, char** argv) {
+  // always use line buffer mode so log messages are available when redirected
+  setvbuf(stdout, NULL, _IOLBF, 0);
+  setvbuf(stderr, NULL, _IOLBF, 0);
+
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   rootcanal::log::SetLogColorEnable(FLAGS_enable_log_color);
 


### PR DESCRIPTION
When the output is not a TTY (e.g. when redirected), glibc switches from line buffering to block buffering for stdout/stderr. Rootcanal's startup log messages aren't enough to fill a block, so it would appear to just not log anything at all. Now, `./rootcanal | cat` behaves as expected: log messages show up immediately.