### PR TITLE
Sync with aosp/main

### DIFF
--- a/desktop/test_environment.cc
+++ b/desktop/test_environment.cc
@@ -118,13 +118,15 @@ void TestEnvironment::SetUpHciServer(
         transport = HciSniffer::Create(transport);
       }
       auto device = HciDevice::Create(transport, properties);
-      test_model_.AddHciConnection(device);
+      auto device_id = test_model_.AddHciConnection(device);
 
       if (enable_hci_sniffer_) {
-        auto filename = device->GetAddress().ToString() + ".pcap";
+        auto filename = "rootcanal_" + std::to_string(device_id) + "_" +
+                        device->GetAddress().ToString() + ".pcap";
         for (auto i = 0; std::filesystem::exists(filename); i++) {
-          filename =
-              device->GetAddress().ToString() + "_" + std::to_string(i) + ".pcap";
+          filename = "rootcanal_" + std::to_string(device_id) + "_" +
+                     device->GetAddress().ToString() + "_" + std::to_string(i) +
+                     ".pcap";
         }
         auto file = std::make_shared<std::ofstream>(filename, std::ios::binary);
         auto sniffer = std::static_pointer_cast<HciSniffer>(transport);

--- a/model/controller/link_layer_controller.cc
+++ b/model/controller/link_layer_controller.cc
@@ -3166,6 +3166,8 @@ void LinkLayerController::ScanIncomingLeLegacyAdvertisingPdu(
     // is connectable in the scan response report.
     scanner_.connectable_scan_response = connectable_advertising;
     scanner_.extended_scan_response = false;
+    scanner_.primary_scan_response_phy = model::packets::PhyType::LE_1M;
+    scanner_.secondary_scan_response_phy = model::packets::PhyType::NO_PACKETS;
     scanner_.pending_scan_request = advertising_address;
     scanner_.pending_scan_request_timeout =
         std::chrono::steady_clock::now() + kScanRequestTimeout;
@@ -3622,6 +3624,8 @@ void LinkLayerController::ScanIncomingLeExtendedAdvertisingPdu(
     // is connectable in the scan response report.
     scanner_.connectable_scan_response = connectable_advertising;
     scanner_.extended_scan_response = true;
+    scanner_.primary_scan_response_phy = primary_phy;
+    scanner_.secondary_scan_response_phy = secondary_phy;
     scanner_.pending_scan_request = advertising_address;
 
     INFO(id_,
@@ -4999,7 +5003,10 @@ void LinkLayerController::IncomingLeScanResponsePacket(
     response.scannable_ = true;
     response.legacy_ = !scanner_.extended_scan_response;
     response.scan_response_ = true;
-    response.primary_phy_ = bluetooth::hci::PrimaryPhyType::LE_1M;
+    response.primary_phy_ = static_cast<bluetooth::hci::PrimaryPhyType>(
+        scanner_.primary_scan_response_phy);
+    response.secondary_phy_ = static_cast<bluetooth::hci::SecondaryPhyType>(
+        scanner_.secondary_scan_response_phy);
     // TODO: SID should be set in scan response PDU
     response.advertising_sid_ = 0xFF;
     response.tx_power_ = 0x7F;

--- a/model/controller/link_layer_controller.h
+++ b/model/controller/link_layer_controller.h
@@ -1071,6 +1071,8 @@ class LinkLayerController {
     // Save information about the advertising PDU being scanned.
     bool connectable_scan_response;
     bool extended_scan_response;
+    model::packets::PhyType primary_scan_response_phy;
+    model::packets::PhyType secondary_scan_response_phy;
     std::optional<AddressWithType> pending_scan_request{};
     std::optional<std::chrono::steady_clock::time_point>
         pending_scan_request_timeout{};

--- a/test/LL/DDI/ADV/BV_11_C.py
+++ b/test/LL/DDI/ADV/BV_11_C.py
@@ -123,7 +123,8 @@ class Test(ControllerTest):
                                  advertising_address_type=ll.AddressType.PUBLIC,
                                  conn_interval=self.LL_initiator_connInterval,
                                  conn_peripheral_latency=self.LL_initiator_connPeripheralLatency,
-                                 conn_supervision_timeout=self.LL_initiator_connSupervisionTimeout))
+                                 conn_supervision_timeout=self.LL_initiator_connSupervisionTimeout),
+            ignored_pdus=[ll.LeLegacyAdvertisingPdu])
 
         # 11. Upper Tester receives an HCI_LE_Connection_Complete event from the IUT including the
         # parameters sent to the IUT in step 8.


### PR DESCRIPTION
Synchronized to packages/modules/Bluetooth
commit 7d904548219fb9a26bbb57803076b27d46d86290

Changelist:
- Report correct Phy type in extended scan response reports
- Make output pcap trace filenames more identifiable
- Remove potential source of flakiness in LL tests
