### PR TITLE
Sync with aosp main

### DIFF
--- a/model/controller/acl_connection_handler.cc
+++ b/model/controller/acl_connection_handler.cc
@@ -92,11 +92,12 @@ uint16_t AclConnectionHandler::CreateLeConnection(AddressWithType addr,
                                                   AddressWithType resolved_peer,
                                                   AddressWithType own_addr,
                                                   bluetooth::hci::Role role,
-                                                  LeAclConnectionParameters connection_parameters) {
+                                                  LeAclConnectionParameters connection_parameters,
+                                                  LeAclSubrateParameters subrate_parameters) {
   uint16_t handle = GetUnusedHandle(le_acl_connections_, ConnectionHandle::kLeAclRangeStart,
                                     ConnectionHandle::kLeAclRangeEnd, last_le_acl_handle_);
   le_acl_connections_.emplace(handle, LeAclConnection{handle, addr, own_addr, resolved_peer, role,
-                                                      connection_parameters});
+                                                      connection_parameters, subrate_parameters});
   return handle;
 }
 

--- a/model/controller/acl_connection_handler.h
+++ b/model/controller/acl_connection_handler.h
@@ -63,7 +63,8 @@ public:
   uint16_t CreateLeConnection(bluetooth::hci::AddressWithType addr,
                               bluetooth::hci::AddressWithType resolved_addr,
                               bluetooth::hci::AddressWithType own_addr, bluetooth::hci::Role role,
-                              LeAclConnectionParameters connection_parameters);
+                              LeAclConnectionParameters connection_parameters,
+                              LeAclSubrateParameters subrate_parameters);
 
   bool Disconnect(uint16_t handle, std::function<void(TaskId)> stopStream);
 

--- a/model/controller/controller_properties.cc
+++ b/model/controller/controller_properties.cc
@@ -117,6 +117,7 @@ static constexpr uint64_t LlFeatures() {
 
           LLFeaturesBits::CONNECTED_ISOCHRONOUS_STREAM_CENTRAL,
           LLFeaturesBits::CONNECTED_ISOCHRONOUS_STREAM_PERIPHERAL,
+          LLFeaturesBits::CONNECTION_SUBRATING,
   };
 
   uint64_t value = 0;
@@ -441,8 +442,8 @@ static std::array<uint8_t, 64> SupportedCommands() {
           // OpCodeIndex::LE_SET_TRANSMIT_POWER_REPORTING_ENABLE,
           // OpCodeIndex::LE_TRANSMITTER_TEST_V4,
           // OpCodeIndex::LE_SET_DATA_RELATED_ADDRESS_CHANGES,
-          // OpCodeIndex::LE_SET_DEFAULT_SUBRATE,
-          // OpCodeIndex::LE_SUBRATE_REQUEST,
+          OpCodeIndex::LE_SET_DEFAULT_SUBRATE,
+          OpCodeIndex::LE_SUBRATE_REQUEST,
   };
 
   std::array<uint8_t, 64> value{};
@@ -1717,14 +1718,21 @@ static std::vector<OpCodeIndex> ll_privacy_commands_ = {
         OpCodeIndex::LE_SET_RESOLVABLE_PRIVATE_ADDRESS_TIMEOUT,
 };
 
-// Commands enabled by the LL Connected Isochronous Stream feature bit.
+// Commands enabled by the Connected Isochronous Stream feature bit.
 // Central and Peripheral support bits are enabled together.
-static std::vector<OpCodeIndex> ll_connected_isochronous_stream_commands_ = {
+static std::vector<OpCodeIndex> connected_isochronous_stream_commands_ = {
         OpCodeIndex::LE_SET_CIG_PARAMETERS,  OpCodeIndex::LE_SET_CIG_PARAMETERS_TEST,
         OpCodeIndex::LE_CREATE_CIS,          OpCodeIndex::LE_REMOVE_CIG,
         OpCodeIndex::LE_ACCEPT_CIS_REQUEST,  OpCodeIndex::LE_REJECT_CIS_REQUEST,
         OpCodeIndex::LE_SETUP_ISO_DATA_PATH, OpCodeIndex::LE_REMOVE_ISO_DATA_PATH,
         OpCodeIndex::LE_REQUEST_PEER_SCA,
+};
+
+// Commands enabled by the Connection Subrating feature bit.
+// Central and Peripheral support bits are enabled together.
+static std::vector<OpCodeIndex> connection_subrating_commands_ = {
+        OpCodeIndex::LE_SET_DEFAULT_SUBRATE,
+        OpCodeIndex::LE_SUBRATE_REQUEST,
 };
 
 static void SetLLFeatureBit(uint64_t& le_features, LLFeaturesBits bit, bool set) {
@@ -1889,8 +1897,14 @@ ControllerProperties::ControllerProperties(rootcanal::configuration::Controller 
                       features.le_connected_isochronous_stream());
       SetLLFeatureBit(le_features, LLFeaturesBits::CONNECTED_ISOCHRONOUS_STREAM_PERIPHERAL,
                       features.le_connected_isochronous_stream());
-      SetSupportedCommandBits(supported_commands, ll_connected_isochronous_stream_commands_,
+      SetSupportedCommandBits(supported_commands, connected_isochronous_stream_commands_,
                               features.le_connected_isochronous_stream());
+    }
+    if (features.has_le_connection_subrating()) {
+      SetLLFeatureBit(le_features, LLFeaturesBits::CONNECTION_SUBRATING,
+                      features.le_connected_isochronous_stream());
+      SetSupportedCommandBits(supported_commands, connection_subrating_commands_,
+                              features.le_connection_subrating());
     }
   }
 

--- a/model/controller/dual_mode_controller.h
+++ b/model/controller/dual_mode_controller.h
@@ -523,6 +523,10 @@ public:
   // 7.8.115
   void LeSetHostFeatureV1(CommandView command);
 
+  // 7.8.123 - 7.8.124
+  void LeSetDefaultSubrate(CommandView command);
+  void LeSubrateRequest(CommandView command);
+
   // Vendor-specific Commands
   void LeGetVendorCapabilities(CommandView command);
   void LeBatchScan(CommandView command);

--- a/model/controller/le_acl_connection.cc
+++ b/model/controller/le_acl_connection.cc
@@ -26,13 +26,15 @@ namespace rootcanal {
 LeAclConnection::LeAclConnection(uint16_t handle, AddressWithType address,
                                  AddressWithType own_address, AddressWithType resolved_address,
                                  bluetooth::hci::Role role,
-                                 LeAclConnectionParameters connection_parameters)
+                                 LeAclConnectionParameters connection_parameters,
+                                 LeAclSubrateParameters subrate_parameters)
     : handle(handle),
       address(address),
       own_address(own_address),
       resolved_address(resolved_address),
       role(role),
       parameters(connection_parameters),
+      subrate_parameters(subrate_parameters),
       last_packet_timestamp_(std::chrono::steady_clock::now()),
       timeout_(std::chrono::seconds(3)) {}
 

--- a/model/controller/le_acl_connection.h
+++ b/model/controller/le_acl_connection.h
@@ -54,6 +54,16 @@ struct LeAclConnectionParameters {
   uint16_t conn_supervision_timeout{};
 };
 
+/// Ranges for acceptable subrate parameters.
+/// LE Default Subrate parameters (Vol 4, Part E § 7.8.123).
+struct LeAclSubrateParameters {
+  uint16_t subrate_min{1};
+  uint16_t subrate_max{1};
+  uint16_t max_latency{0};
+  uint16_t continuation_number{0};
+  uint16_t supervision_timeout{0x0c80};
+};
+
 // Model the LE connection of a device to the controller.
 class LeAclConnection final {
 public:
@@ -64,10 +74,11 @@ public:
   const bluetooth::hci::Role role;
 
   LeAclConnectionParameters parameters;
+  LeAclSubrateParameters subrate_parameters;
 
   LeAclConnection(uint16_t handle, AddressWithType address, AddressWithType own_address,
                   AddressWithType resolved_address, bluetooth::hci::Role role,
-                  LeAclConnectionParameters parameters);
+                  LeAclConnectionParameters parameters, LeAclSubrateParameters subrate_parameters);
   ~LeAclConnection() = default;
 
   void Encrypt();

--- a/model/controller/le_controller.h
+++ b/model/controller/le_controller.h
@@ -151,8 +151,6 @@ public:
   void LeScanning();
   void LeSynchronization();
 
-  void LeConnectionUpdateComplete(uint16_t handle, uint16_t interval_min, uint16_t interval_max,
-                                  uint16_t latency, uint16_t supervision_timeout);
   ErrorCode LeConnectionUpdate(uint16_t handle, uint16_t interval_min, uint16_t interval_max,
                                uint16_t latency, uint16_t supervision_timeout);
   ErrorCode LeRemoteConnectionParameterRequestReply(uint16_t connection_handle,
@@ -471,6 +469,15 @@ public:
   // HCI LE Clear Periodic Advertiser List command (Vol 4, Part E § 7.8.72).
   ErrorCode LeClearPeriodicAdvertiserList();
 
+  // HCI LE Set Default Subrate command (Vol 4, Part E § 7.8.123).
+  ErrorCode LeSetDefaultSubrate(uint16_t subrate_min, uint16_t subrate_max, uint16_t max_latency,
+                                uint16_t continuation_number, uint16_t supervision_timeout);
+
+  // HCI LE Subrate Request command (Vol 4, Part E § 7.8.124).
+  ErrorCode LeSubrateRequest(uint16_t connection_handle, uint16_t subrate_min, uint16_t subrate_max,
+                             uint16_t max_latency, uint16_t continuation_number,
+                             uint16_t supervision_timeout);
+
   // LE APCF
 
   ErrorCode LeApcfEnable(bool apcf_enable);
@@ -582,6 +589,11 @@ protected:
   void IncomingLlPhyUpdateInd(LeAclConnection& connection,
                               model::packets::LinkLayerPacketView incoming);
 
+  void IncomingLlSubrateReq(LeAclConnection& connection,
+                            model::packets::LinkLayerPacketView incoming);
+  void IncomingLlSubrateInd(LeAclConnection& connection,
+                            model::packets::LinkLayerPacketView incoming);
+
 public:
   bool IsEventUnmasked(bluetooth::hci::EventCode event) const;
   bool IsLeEventUnmasked(bluetooth::hci::SubeventCode subevent) const;
@@ -660,6 +672,9 @@ private:
   // Suggested Default Data Length (Vol 4, Part E § 7.8.34).
   uint16_t le_suggested_max_tx_octets_{0x001b};
   uint16_t le_suggested_max_tx_time_{0x0148};
+
+  // LE Default Subrate parameters (Vol 4, Part E § 7.8.123).
+  LeAclSubrateParameters default_subrate_parameters_{};
 
   // Resolvable Private Address Timeout (Vol 4, Part E § 7.8.45).
   std::chrono::seconds resolvable_private_address_timeout_{0x0384};

--- a/packets/hci_packets.pdl
+++ b/packets/hci_packets.pdl
@@ -1512,8 +1512,8 @@ packet EnhancedSetupSynchronousConnection : Command (op_code = ENHANCED_SETUP_SY
   output_coding_format : ScoCodingFormat,
   // Next two items
   // Size, in bits, of the sample or framed data
-  input_coded_data_bits : 16,
-  output_coded_data_bits : 16,
+  input_coded_data_size : 16,
+  output_coded_data_size : 16,
   input_pcm_data_format : ScoPcmDataFormat,
   output_pcm_data_format : ScoPcmDataFormat,
   // Next two items
@@ -1527,8 +1527,8 @@ packet EnhancedSetupSynchronousConnection : Command (op_code = ENHANCED_SETUP_SY
   // [1, 255] The number of bits in each unit of data received from the Host
   //          over the audio data transport.
   // [0] Not applicable (implied by the choice of audio data transport)
-  input_transport_unit_bits : 8,
-  output_transport_unit_bits : 8,
+  input_transport_unit_size : 8,
+  output_transport_unit_size : 8,
   // [0x0004, 0xFFFE]: in milliseconds
   //     Upper limit represent the sum of the synchronous interval and the size
   //     of the eSCO window, where the eSCO window is reserved slots plus the
@@ -1568,8 +1568,8 @@ packet EnhancedAcceptSynchronousConnection : Command (op_code = ENHANCED_ACCEPT_
   output_coding_format : ScoCodingFormat,
   // Next two items
   // Size, in bits, of the sample or framed data
-  input_coded_data_bits : 16,
-  output_coded_data_bits : 16,
+  input_coded_data_size : 16,
+  output_coded_data_size : 16,
   input_pcm_data_format : ScoPcmDataFormat,
   output_pcm_data_format : ScoPcmDataFormat,
   // Next two items
@@ -1583,8 +1583,8 @@ packet EnhancedAcceptSynchronousConnection : Command (op_code = ENHANCED_ACCEPT_
   // [1, 255] The number of bits in each unit of data received from the Host
   //          over the audio data transport.
   // [0] Not applicable (implied by the choice of audio data transport)
-  input_transport_unit_bits : 8,
-  output_transport_unit_bits : 8,
+  input_transport_unit_size : 8,
+  output_transport_unit_size : 8,
   // [0x0004, 0xFFFE]: in milliseconds
   //     Upper limit represent the sum of the synchronous interval and the size
   //     of the eSCO window, where the eSCO window is reserved slots plus the
@@ -1761,9 +1761,9 @@ packet FlowSpecificationStatus : CommandStatus (command_op_code = FLOW_SPECIFICA
 packet SniffSubrating : Command (op_code = SNIFF_SUBRATING) {
   connection_handle : 12,
   _reserved_ : 4,
-  maximum_latency : 16,  // 0x0002-0xFFFE (1.25ms-40.9s)
-  minimum_remote_timeout : 16, // 0x0000-0xFFFE (0-40.9s)
-  minimum_local_timeout: 16, // 0x0000-0xFFFE (0-40.9s)
+  max_latency : 16,  // 0x0002-0xFFFE (1.25ms-40.9s)
+  min_remote_timeout : 16, // 0x0000-0xFFFE (0-40.9s)
+  min_local_timeout: 16, // 0x0000-0xFFFE (0-40.9s)
 }
 
 packet SniffSubratingComplete : CommandComplete (command_op_code = SNIFF_SUBRATING) {
@@ -4824,16 +4824,11 @@ packet LeSetDataRelatedAddressChangesComplete : CommandComplete (command_op_code
 }
 
 packet LeSetDefaultSubrate : Command (op_code = LE_SET_DEFAULT_SUBRATE) {
-  subrate_min : 9,
-  _reserved_ : 7,
-  subrate_max : 9,
-  _reserved_ : 7,
-  max_latency : 9,
-  _reserved_ : 7,
-  continuation_number : 9,
-  _reserved_ : 7,
-  supervision_timeout: 12,
-  _reserved_ : 4,
+  subrate_min : 16,
+  subrate_max : 16,
+  max_latency : 16,
+  continuation_number : 16,
+  supervision_timeout : 16,
 }
 
 packet LeSetDefaultSubrateComplete : CommandComplete (command_op_code = LE_SET_DEFAULT_SUBRATE) {
@@ -4843,16 +4838,11 @@ packet LeSetDefaultSubrateComplete : CommandComplete (command_op_code = LE_SET_D
 packet LeSubrateRequest : Command (op_code = LE_SUBRATE_REQUEST) {
   connection_handle : 12,
   _reserved_ : 4,
-  subrate_min : 9,
-  _reserved_ : 7,
-  subrate_max : 9,
-  _reserved_ : 7,
-  max_latency : 9,
-  _reserved_ : 7,
-  continuation_number : 9,
-  _reserved_ : 7,
-  supervision_timeout: 12,
-  _reserved_ : 4,
+  subrate_min : 16,
+  subrate_max : 16,
+  max_latency : 16,
+  continuation_number : 16,
+  supervision_timeout : 16,
 }
 
 packet LeSubrateRequestStatus : CommandStatus (command_op_code = LE_SUBRATE_REQUEST) {

--- a/packets/link_layer_packets.pdl
+++ b/packets/link_layer_packets.pdl
@@ -57,6 +57,9 @@ enum PacketType : 8 {
     LL_PHY_REQ = 0x50,
     LL_PHY_RSP = 0x51,
     LL_PHY_UPDATE_IND = 0x52,
+
+    LL_SUBRATE_REQ = 0x53,
+    LL_SUBRATE_IND = 0x54,
 }
 
 packet LinkLayerPacket {
@@ -375,4 +378,22 @@ packet LlPhyUpdateInd : LinkLayerPacket (type = LL_PHY_UPDATE_IND) {
   phy_c_to_p: 8,
   phy_p_to_c: 8,
   instant: 16,
+}
+
+packet LlSubrateReq : LinkLayerPacket (type = LL_SUBRATE_REQ) {
+  subrate_factor_min: 16,
+  subrate_factor_max: 16,
+  max_latency: 16,
+  continuation_number: 16,
+  timeout: 16,
+}
+
+packet LlSubrateInd : LinkLayerPacket (type = LL_SUBRATE_IND) {
+  // Not part of the LL PDU, added to emulate LL_REJECT_EXT_IND.
+  status: 8,
+  subrate_factor: 16,
+  subrate_base_event: 16,
+  latency: 16,
+  continuation_number: 16,
+  timeout: 16,
 }

--- a/proto/rootcanal/configuration.proto
+++ b/proto/rootcanal/configuration.proto
@@ -37,6 +37,7 @@ message ControllerFeatures {
   // Enable the support for both LL Connected Isochronous Stream Central
   // and LL Connected Isochronous Stream Peripheral.
   optional bool le_connected_isochronous_stream = 6;
+  optional bool le_connection_subrating = 7;
 }
 
 message ControllerQuirks {

--- a/rust/src/lmp/procedure/legacy_pairing.rs
+++ b/rust/src/lmp/procedure/legacy_pairing.rs
@@ -40,7 +40,7 @@ pub async fn initiate(ctx: &impl Context) -> Result<(), ()> {
     let _ = ctx.receive_lmp_packet::<lmp::CombKey>().await;
 
     // Post pairing authentication
-    let link_key = [0; 16];
+    let link_key = [1; 16];
     let auth_result = authentication::send_challenge(ctx, 0, link_key).await;
     authentication::receive_challenge(ctx, link_key).await;
 
@@ -74,7 +74,7 @@ pub async fn respond(ctx: &impl Context, _request: lmp::InRand) -> Result<(), ()
     ctx.send_lmp_packet(lmp::CombKey { transaction_id: 0, random_number: [0; 16] });
 
     // Post pairing authentication
-    let link_key = [0; 16];
+    let link_key = [1; 16];
     authentication::receive_challenge(ctx, link_key).await;
     let auth_result = authentication::send_challenge(ctx, 0, link_key).await;
 

--- a/rust/src/lmp/procedure/secure_simple_pairing.rs
+++ b/rust/src/lmp/procedure/secure_simple_pairing.rs
@@ -194,7 +194,10 @@ async fn send_commitment(ctx: &impl Context, confirm: lmp::SimplePairingConfirm)
 async fn user_confirmation_request(ctx: &impl Context) -> Result<(), ()> {
     ctx.send_hci_event(hci::UserConfirmationRequest {
         bd_addr: ctx.peer_address(),
-        numeric_value: 0,
+        // We are using a fixed numeric value here, but in a proper controller the
+        // value would be randomly generated. For the purpose of automated virtual
+        // testing it is not that important to do that.
+        numeric_value: 27,
     });
 
     match ctx
@@ -502,7 +505,7 @@ pub async fn initiate(ctx: &impl Context) -> Result<(), ()> {
     });
 
     // Link Key Calculation
-    let link_key = [0; 16];
+    let link_key = [1; 16];
     let auth_result = authentication::send_challenge(ctx, 0, link_key).await;
     authentication::receive_challenge(ctx, link_key).await;
 
@@ -730,7 +733,7 @@ pub async fn respond(ctx: &impl Context, request: lmp::IoCapabilityReq) -> Resul
     });
 
     // Link Key Calculation
-    let link_key = [0; 16];
+    let link_key = [1; 16];
     authentication::receive_challenge(ctx, link_key).await;
     let auth_result = authentication::send_challenge(ctx, 0, link_key).await;
 

--- a/rust/test/SP/BV-05-C.in
+++ b/rust/test/SP/BV-05-C.in
@@ -81,7 +81,7 @@ sequence! { procedure, context,
     IUT -> Upper Tester: LinkKeyNotification {
         bd_addr: context.peer_address(),
         key_type: KeyType::AuthenticatedP192,
-        link_key: [0; 16],
+        link_key: [1; 16],
     }
     IUT -> Lower Tester: AuRand {
         transaction_id: 0,

--- a/rust/test/SP/BV-06-C.in
+++ b/rust/test/SP/BV-06-C.in
@@ -108,7 +108,7 @@ sequence! { procedure, context,
         transaction_id: 0,
         nonce: [0; 16],
     }
-    IUT -> Upper Tester: UserConfirmationRequest { bd_addr: context.peer_address(), numeric_value: 0 }
+    IUT -> Upper Tester: UserConfirmationRequest { bd_addr: context.peer_address(), numeric_value: 27 }
     IUT -> Lower Tester: Accepted {
         transaction_id: 0,
         accepted_opcode: Opcode::SimplePairingNumber,
@@ -154,7 +154,7 @@ sequence! { procedure, context,
     IUT -> Upper Tester: LinkKeyNotification {
         bd_addr: context.peer_address(),
         key_type: KeyType::AuthenticatedP192,
-        link_key: [0; 16],
+        link_key: [1; 16],
     }
     IUT -> Upper Tester: AuthenticationComplete {
         status: ErrorCode::Success,

--- a/rust/test/SP/BV-07-C.in
+++ b/rust/test/SP/BV-07-C.in
@@ -94,7 +94,7 @@ sequence! { procedure, context,
         transaction_id: 0,
         accepted_opcode: Opcode::SimplePairingNumber,
     }
-    IUT -> Upper Tester: UserConfirmationRequest { bd_addr: context.peer_address(), numeric_value: 0 }
+    IUT -> Upper Tester: UserConfirmationRequest { bd_addr: context.peer_address(), numeric_value: 27 }
     Upper Tester -> IUT: UserConfirmationRequestReply { bd_addr: context.peer_address() }
     IUT -> Upper Tester: UserConfirmationRequestReplyComplete {
         num_hci_command_packets: 1,
@@ -136,6 +136,6 @@ sequence! { procedure, context,
     IUT -> Upper Tester: LinkKeyNotification {
         bd_addr: context.peer_address(),
         key_type: KeyType::AuthenticatedP192,
-        link_key: [0; 16],
+        link_key: [1; 16],
     }
 }

--- a/rust/test/SP/BV-08-C.in
+++ b/rust/test/SP/BV-08-C.in
@@ -108,7 +108,7 @@ sequence! { procedure, context,
         transaction_id: 0,
         nonce: [0; 16],
     }
-    IUT -> Upper Tester: UserConfirmationRequest { bd_addr: context.peer_address(), numeric_value: 0 }
+    IUT -> Upper Tester: UserConfirmationRequest { bd_addr: context.peer_address(), numeric_value: 27 }
     IUT -> Lower Tester: Accepted {
         transaction_id: 0,
         accepted_opcode: Opcode::SimplePairingNumber,

--- a/rust/test/SP/BV-09-C.in
+++ b/rust/test/SP/BV-09-C.in
@@ -94,7 +94,7 @@ sequence! { procedure, context,
         transaction_id: 0,
         accepted_opcode: Opcode::SimplePairingNumber,
     }
-    IUT -> Upper Tester: UserConfirmationRequest { bd_addr: context.peer_address(), numeric_value: 0 }
+    IUT -> Upper Tester: UserConfirmationRequest { bd_addr: context.peer_address(), numeric_value: 27 }
     Upper Tester -> IUT: UserConfirmationRequestReply { bd_addr: context.peer_address() }
     IUT -> Upper Tester: UserConfirmationRequestReplyComplete {
         num_hci_command_packets: 1,

--- a/rust/test/SP/BV-10-C.in
+++ b/rust/test/SP/BV-10-C.in
@@ -108,7 +108,7 @@ sequence! { procedure, context,
         transaction_id: 0,
         nonce: [0; 16],
     }
-    IUT -> Upper Tester: UserConfirmationRequest { bd_addr: context.peer_address(), numeric_value: 0 }
+    IUT -> Upper Tester: UserConfirmationRequest { bd_addr: context.peer_address(), numeric_value: 27 }
     IUT -> Lower Tester: Accepted {
         transaction_id: 0,
         accepted_opcode: Opcode::SimplePairingNumber,

--- a/rust/test/SP/BV-11-C.in
+++ b/rust/test/SP/BV-11-C.in
@@ -94,7 +94,7 @@ sequence! { procedure, context,
         transaction_id: 0,
         accepted_opcode: Opcode::SimplePairingNumber,
     }
-    IUT -> Upper Tester: UserConfirmationRequest { bd_addr: context.peer_address(), numeric_value: 0 }
+    IUT -> Upper Tester: UserConfirmationRequest { bd_addr: context.peer_address(), numeric_value: 27 }
     Upper Tester -> IUT: UserConfirmationRequestNegativeReply { bd_addr: context.peer_address() }
     IUT -> Upper Tester: UserConfirmationRequestNegativeReplyComplete {
         num_hci_command_packets: 1,

--- a/rust/test/SP/BV-12-C.in
+++ b/rust/test/SP/BV-12-C.in
@@ -165,7 +165,7 @@ sequence! { procedure, context,
     IUT -> Upper Tester: LinkKeyNotification {
         bd_addr: context.peer_address(),
         key_type: KeyType::AuthenticatedP192,
-        link_key: [0; 16],
+        link_key: [1; 16],
     }
     IUT -> Upper Tester: AuthenticationComplete {
         status: ErrorCode::Success,

--- a/rust/test/SP/BV-13-C.in
+++ b/rust/test/SP/BV-13-C.in
@@ -136,6 +136,6 @@ sequence! { procedure, context,
     IUT -> Upper Tester: LinkKeyNotification {
         bd_addr: context.peer_address(),
         key_type: KeyType::AuthenticatedP192,
-        link_key: [0; 16],
+        link_key: [1; 16],
     }
 }

--- a/rust/test/SP/BV-18-C.in
+++ b/rust/test/SP/BV-18-C.in
@@ -156,7 +156,7 @@ sequence! { procedure, context,
     IUT -> Upper Tester: LinkKeyNotification {
         bd_addr: context.peer_address(),
         key_type: KeyType::AuthenticatedP192,
-        link_key: [0; 16],
+        link_key: [1; 16],
     }
     IUT -> Upper Tester: AuthenticationComplete {
         status: ErrorCode::Success,

--- a/rust/test/SP/BV-19-C.in
+++ b/rust/test/SP/BV-19-C.in
@@ -138,6 +138,6 @@ sequence! { procedure, context,
     IUT -> Upper Tester: LinkKeyNotification {
         bd_addr: context.peer_address(),
         key_type: KeyType::AuthenticatedP192,
-        link_key: [0; 16],
+        link_key: [1; 16],
     }
 }

--- a/rust/test/SP/BV-20-C.in
+++ b/rust/test/SP/BV-20-C.in
@@ -149,7 +149,7 @@ sequence! { procedure, context,
     IUT -> Upper Tester: LinkKeyNotification {
         bd_addr: context.peer_address(),
         key_type: KeyType::AuthenticatedP192,
-        link_key: [0; 16],
+        link_key: [1; 16],
     }
     IUT -> Upper Tester: AuthenticationComplete {
         status: ErrorCode::Success,

--- a/rust/test/SP/BV-21-C.in
+++ b/rust/test/SP/BV-21-C.in
@@ -131,6 +131,6 @@ sequence! { procedure, context,
     IUT -> Upper Tester: LinkKeyNotification {
         bd_addr: context.peer_address(),
         key_type: KeyType::AuthenticatedP192,
-        link_key: [0; 16],
+        link_key: [1; 16],
     }
 }

--- a/rust/test/SP/BV-22-C.in
+++ b/rust/test/SP/BV-22-C.in
@@ -162,7 +162,7 @@ sequence! { procedure, context,
     IUT -> Upper Tester: LinkKeyNotification {
         bd_addr: context.peer_address(),
         key_type: KeyType::AuthenticatedP192,
-        link_key: [0; 16],
+        link_key: [1; 16],
     }
     IUT -> Upper Tester: AuthenticationComplete {
         status: ErrorCode::Success,

--- a/rust/test/SP/BV-23-C.in
+++ b/rust/test/SP/BV-23-C.in
@@ -144,6 +144,6 @@ sequence! { procedure, context,
     IUT -> Upper Tester: LinkKeyNotification {
         bd_addr: context.peer_address(),
         key_type: KeyType::AuthenticatedP192,
-        link_key: [0; 16],
+        link_key: [1; 16],
     }
 }

--- a/rust/test/SP/BV-33-C.in
+++ b/rust/test/SP/BV-33-C.in
@@ -191,7 +191,7 @@ sequence! { procedure, context,
     IUT -> Upper Tester: LinkKeyNotification {
         bd_addr: context.peer_address(),
         key_type: KeyType::AuthenticatedP192,
-        link_key: [0; 16],
+        link_key: [1; 16],
     }
     IUT -> Upper Tester: AuthenticationComplete {
         status: ErrorCode::Success,

--- a/rust/test/SP/BV-34-C.in
+++ b/rust/test/SP/BV-34-C.in
@@ -152,6 +152,6 @@ sequence! { procedure, context,
     IUT -> Upper Tester: LinkKeyNotification {
         bd_addr: context.peer_address(),
         key_type: KeyType::AuthenticatedP192,
-        link_key: [0; 16],
+        link_key: [1; 16],
     }
 }

--- a/test/LL/cig_reconfiguration.py
+++ b/test/LL/cig_reconfiguration.py
@@ -1,0 +1,282 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import hci_packets as hci
+import link_layer_packets as ll
+import llcp_packets as llcp
+import random
+import unittest
+from hci_packets import ErrorCode
+from py.bluetooth import Address
+from py.controller import ControllerTest, generate_rpa
+
+
+class Test(ControllerTest):
+
+    SDU_Interval_C_TO_P = 10000  # 10ms
+    SDU_Interval_P_TO_C = 10000  # 10ms
+    ISO_Interval = 16  # 20ms
+    Sub_Interval = 7500  # 7.5ms (approximation)
+    CIG_Sync_Delay = 7500  # 7.5ms (approximation)
+    CIS_Sync_Delay = 7500  # 7.5ms (approximation)
+    Worst_Case_SCA = hci.ClockAccuracy.PPM_500
+    Packing = hci.Packing.SEQUENTIAL
+    Framing = hci.Enable.DISABLED
+    NSE = 4
+    Max_SDU_C_TO_P = 130
+    Max_SDU_P_TO_C = 130
+    Max_PDU_C_TO_P = 130
+    Max_PDU_P_TO_C = 130
+    PHY_C_TO_P = 0x1
+    PHY_P_TO_C = 0x1
+    FT_C_TO_P = 1
+    FT_P_TO_C = 1
+    BN_C_TO_P = 2
+    BN_P_TO_C = 2
+    Max_Transport_Latency_C_TO_P = 40000  # 40ms
+    Max_Transport_Latency_P_TO_C = 40000  # 40ms
+    RTN_C_TO_P = 3
+    RTN_P_TO_C = 3
+
+    # Verify that the CIG can be reconfigured while in configurable state.
+    async def test_reconfiguration_success(self):
+        # Test parameters.
+        cig_id = 0x12
+        cis_id = 0x42
+        peer_address = Address('aa:bb:cc:dd:ee:ff')
+        controller = self.controller
+
+        # Enable Connected Isochronous Stream Host Support.
+        await self.enable_connected_isochronous_stream_host_support()
+
+        # Create the CIG.
+        controller.send_cmd(
+            hci.LeSetCigParametersTest(cig_id=cig_id,
+                                       sdu_interval_c_to_p=self.SDU_Interval_C_TO_P,
+                                       sdu_interval_p_to_c=self.SDU_Interval_P_TO_C,
+                                       ft_c_to_p=self.FT_C_TO_P,
+                                       ft_p_to_c=self.FT_P_TO_C,
+                                       iso_interval=self.ISO_Interval,
+                                       worst_case_sca=self.Worst_Case_SCA,
+                                       packing=self.Packing,
+                                       framing=self.Framing,
+                                       cis_config=[
+                                           hci.LeCisParametersTestConfig(
+                                               cis_id=cis_id,
+                                               nse=self.NSE,
+                                               max_sdu_c_to_p=self.Max_SDU_C_TO_P,
+                                               max_sdu_p_to_c=self.Max_SDU_P_TO_C,
+                                               max_pdu_c_to_p=self.Max_PDU_C_TO_P,
+                                               max_pdu_p_to_c=self.Max_PDU_P_TO_C,
+                                               phy_c_to_p=self.PHY_C_TO_P,
+                                               phy_p_to_c=self.PHY_P_TO_C,
+                                               bn_c_to_p=self.BN_C_TO_P,
+                                               bn_p_to_c=self.BN_P_TO_C)
+                                       ]))
+
+        await self.expect_evt(
+            hci.LeSetCigParametersTestComplete(status=ErrorCode.SUCCESS,
+                                               num_hci_command_packets=1,
+                                               cig_id=cig_id,
+                                               connection_handle=[self.Any]))
+
+        # Attempt CIG reconfiguration with the same values.
+        controller.send_cmd(
+            hci.LeSetCigParametersTest(cig_id=cig_id,
+                                       sdu_interval_c_to_p=self.SDU_Interval_C_TO_P,
+                                       sdu_interval_p_to_c=self.SDU_Interval_P_TO_C,
+                                       ft_c_to_p=self.FT_C_TO_P,
+                                       ft_p_to_c=self.FT_P_TO_C,
+                                       iso_interval=self.ISO_Interval,
+                                       worst_case_sca=self.Worst_Case_SCA,
+                                       packing=self.Packing,
+                                       framing=self.Framing,
+                                       cis_config=[
+                                           hci.LeCisParametersTestConfig(
+                                               cis_id=cis_id,
+                                               nse=self.NSE,
+                                               max_sdu_c_to_p=self.Max_SDU_C_TO_P,
+                                               max_sdu_p_to_c=self.Max_SDU_P_TO_C,
+                                               max_pdu_c_to_p=self.Max_PDU_C_TO_P,
+                                               max_pdu_p_to_c=self.Max_PDU_P_TO_C,
+                                               phy_c_to_p=self.PHY_C_TO_P,
+                                               phy_p_to_c=self.PHY_P_TO_C,
+                                               bn_c_to_p=self.BN_C_TO_P,
+                                               bn_p_to_c=self.BN_P_TO_C)
+                                       ]))
+
+        await self.expect_evt(
+            hci.LeSetCigParametersTestComplete(status=ErrorCode.SUCCESS,
+                                               num_hci_command_packets=1,
+                                               cig_id=cig_id,
+                                               connection_handle=[self.Any]))
+
+    # Verify that the CIG reconfiguration attempt is rejected when the CIG is active.
+    async def test_reconfiguration_disallowed(self):
+        # Test parameters.
+        cig_id = 0x12
+        cis_id = 0x42
+        peer_address = Address('aa:bb:cc:dd:ee:ff')
+        controller = self.controller
+
+        # Enable Connected Isochronous Stream Host Support.
+        await self.enable_connected_isochronous_stream_host_support()
+
+        # Prelude: Establish an ACL connection as peripheral with the IUT.
+        acl_connection_handle = await self.establish_le_connection_central(peer_address)
+
+        # Create the CIG.
+        controller.send_cmd(
+            hci.LeSetCigParametersTest(cig_id=cig_id,
+                                       sdu_interval_c_to_p=self.SDU_Interval_C_TO_P,
+                                       sdu_interval_p_to_c=self.SDU_Interval_P_TO_C,
+                                       ft_c_to_p=self.FT_C_TO_P,
+                                       ft_p_to_c=self.FT_P_TO_C,
+                                       iso_interval=self.ISO_Interval,
+                                       worst_case_sca=self.Worst_Case_SCA,
+                                       packing=self.Packing,
+                                       framing=self.Framing,
+                                       cis_config=[
+                                           hci.LeCisParametersTestConfig(
+                                               cis_id=cis_id,
+                                               nse=self.NSE,
+                                               max_sdu_c_to_p=self.Max_SDU_C_TO_P,
+                                               max_sdu_p_to_c=self.Max_SDU_P_TO_C,
+                                               max_pdu_c_to_p=self.Max_PDU_C_TO_P,
+                                               max_pdu_p_to_c=self.Max_PDU_P_TO_C,
+                                               phy_c_to_p=self.PHY_C_TO_P,
+                                               phy_p_to_c=self.PHY_P_TO_C,
+                                               bn_c_to_p=self.BN_C_TO_P,
+                                               bn_p_to_c=self.BN_P_TO_C)
+                                       ]))
+
+        event = await self.expect_evt(
+            hci.LeSetCigParametersTestComplete(status=ErrorCode.SUCCESS,
+                                               num_hci_command_packets=1,
+                                               cig_id=cig_id,
+                                               connection_handle=[self.Any]))
+        cis_connection_handle = event.connection_handle[0]
+
+        # The Upper Tester sends an HCI_LE_Create_CIS command to the IUT with the
+        # ACL_Connection_Handle of the established ACL connection and CIS_Count set to 1. The Upper
+        # Tester receives a Status of Success from the IUT.
+        controller.send_cmd(
+            hci.LeCreateCis(cis_config=[
+                hci.LeCreateCisConfig(cis_connection_handle=cis_connection_handle,
+                                      acl_connection_handle=acl_connection_handle)
+            ]))
+
+        await self.expect_evt(
+            hci.LeCreateCisStatus(status=ErrorCode.SUCCESS, num_hci_command_packets=1))
+
+        # The Lower Tester receives an LL_CIS_REQ PDU from the IUT with all fields set to valid values.
+        # CIS_Offset_Min is a value between 500µs and TSPX_conn_interval, CIS_Offset_Max is a value
+        # between CIS_Offset_Min and the CIS_Offset_Max value as calculated in [14] Section 2.4.2.29
+        # using TSPX_conn_interval as the value of connInterval, and connEventCount is the reference
+        # event anchor point for which the offsets applied.
+        cis_req = await self.expect_llcp(source_address=controller.address,
+                                         destination_address=peer_address,
+                                         expected_pdu=llcp.CisReq(
+                                             cig_id=cig_id,
+                                             cis_id=cis_id,
+                                             phy_c_to_p=hci.PhyType.LE_1M,
+                                             phy_p_to_c=hci.PhyType.LE_1M,
+                                             framed=self.Framing == hci.Enable.ENABLED,
+                                             max_sdu_c_to_p=self.Max_SDU_C_TO_P,
+                                             max_sdu_p_to_c=self.Max_SDU_P_TO_C,
+                                             sdu_interval_c_to_p=self.SDU_Interval_C_TO_P,
+                                             sdu_interval_p_to_c=self.SDU_Interval_P_TO_C,
+                                             max_pdu_c_to_p=self.Max_PDU_C_TO_P,
+                                             max_pdu_p_to_c=self.Max_PDU_P_TO_C,
+                                             nse=self.NSE,
+                                             sub_interval=self.Any,
+                                             bn_p_to_c=self.BN_C_TO_P,
+                                             bn_c_to_p=self.BN_P_TO_C,
+                                             ft_c_to_p=self.FT_C_TO_P,
+                                             ft_p_to_c=self.FT_P_TO_C,
+                                             iso_interval=self.ISO_Interval,
+                                             cis_offset_min=self.Any,
+                                             cis_offset_max=self.Any,
+                                             conn_event_count=0))
+        # The Lower Tester sends an LL_CIS_RSP PDU to the IUT.
+        controller.send_llcp(source_address=peer_address,
+                             destination_address=controller.address,
+                             pdu=llcp.CisRsp(cis_offset_min=cis_req.cis_offset_min,
+                                             cis_offset_max=cis_req.cis_offset_max,
+                                             conn_event_count=0))
+
+        # The Lower Tester receives an LL_CIS_IND from the IUT where the CIS_Offset is the time (ms)
+        # from the start of the ACL connection event in connEvent Count to the first CIS anchor point, the
+        # CIS_Sync_Delay is CIG_Sync_Delay minus the offset from the CIG reference point to the CIS
+        # anchor point in s, and the connEventCount is the CIS_Offset reference point.
+        cis_ind = await self.expect_llcp(source_address=controller.address,
+                                         destination_address=peer_address,
+                                         expected_pdu=llcp.CisInd(aa=0,
+                                                                  cis_offset=self.Any,
+                                                                  cig_sync_delay=self.Any,
+                                                                  cis_sync_delay=self.Any,
+                                                                  conn_event_count=0))
+
+        # 7. The Upper Tester receives a successful HCI_LE_CIS_Established event with the NSE, BN, FT,
+        # and Max_PDU parameters as set in step 1 from the IUT, after the first CIS packet sent by the LT.
+        # The Connection_Handle parameter is set to the value provided in the HCI_LE_Create_CIS
+        # command.
+        await self.expect_evt(
+            hci.LeCisEstablishedV1(status=ErrorCode.SUCCESS,
+                                   connection_handle=cis_connection_handle,
+                                   cig_sync_delay=cis_ind.cig_sync_delay,
+                                   cis_sync_delay=cis_ind.cis_sync_delay,
+                                   transport_latency_c_to_p=self.Any,
+                                   transport_latency_p_to_c=self.Any,
+                                   phy_c_to_p=hci.SecondaryPhyType.LE_1M,
+                                   phy_p_to_c=hci.SecondaryPhyType.LE_1M,
+                                   nse=self.NSE,
+                                   bn_c_to_p=self.BN_C_TO_P,
+                                   bn_p_to_c=self.BN_P_TO_C,
+                                   ft_c_to_p=self.FT_C_TO_P,
+                                   ft_p_to_c=self.FT_P_TO_C,
+                                   max_pdu_c_to_p=self.Max_PDU_C_TO_P,
+                                   max_pdu_p_to_c=self.Max_PDU_P_TO_C,
+                                   iso_interval=self.ISO_Interval))
+
+        # Attempt CIG reconfiguration with the same values.
+        controller.send_cmd(
+            hci.LeSetCigParametersTest(cig_id=cig_id,
+                                       sdu_interval_c_to_p=self.SDU_Interval_C_TO_P,
+                                       sdu_interval_p_to_c=self.SDU_Interval_P_TO_C,
+                                       ft_c_to_p=self.FT_C_TO_P,
+                                       ft_p_to_c=self.FT_P_TO_C,
+                                       iso_interval=self.ISO_Interval,
+                                       worst_case_sca=self.Worst_Case_SCA,
+                                       packing=self.Packing,
+                                       framing=self.Framing,
+                                       cis_config=[
+                                           hci.LeCisParametersTestConfig(
+                                               cis_id=cis_id,
+                                               nse=self.NSE,
+                                               max_sdu_c_to_p=self.Max_SDU_C_TO_P,
+                                               max_sdu_p_to_c=self.Max_SDU_P_TO_C,
+                                               max_pdu_c_to_p=self.Max_PDU_C_TO_P,
+                                               max_pdu_p_to_c=self.Max_PDU_P_TO_C,
+                                               phy_c_to_p=self.PHY_C_TO_P,
+                                               phy_p_to_c=self.PHY_P_TO_C,
+                                               bn_c_to_p=self.BN_C_TO_P,
+                                               bn_p_to_c=self.BN_P_TO_C)
+                                       ]))
+
+        await self.expect_evt(
+            hci.LeSetCigParametersTestComplete(status=ErrorCode.COMMAND_DISALLOWED,
+                                               num_hci_command_packets=1,
+                                               cig_id=cig_id,
+                                               connection_handle=[]))


### PR DESCRIPTION
Synchronized to tools/rootcanal
    commit fc1283d0d8bb5bf7939d870cf62cd59346c697db

Changelist:
- BrEdrController: Cleanup HCI commands
- BrEdrController: Partially implement QoS Setup (fix #43)
- LeController: Support re-configuration of CIGs (fix #47)
- Fix crash in VLog by avoiding fmt::print on stdout
- pairing: Return non-zero numeric value in User Confirmation Request
- pairing: Return non-empty link-keys
- RootCanal: Implement support for Connection Subrating
- LinkLayerController: Cleanup the implementation of LE Connection Parameter update procedure
